### PR TITLE
Wrap the Docker client: always reconnect.

### DIFF
--- a/appstart/utils.py
+++ b/appstart/utils.py
@@ -93,6 +93,19 @@ def check_docker_version(dclient):
                             'anyway'.format(DOCKER_SERVER_VERSION,
                                             server_version))
 
+# TODO(mmuller): "ClientWrapper" is a pretty horrible kludge.  Rewrite it so
+# that it doesn't indiscriminately reconnect every time an attribute is
+# accessed.
+
+
+class ClientWrapper(object):
+
+    def __init__(self, **params):
+        self.__params = params
+
+    def __getattr__(self, attrname):
+        return getattr(docker.Client(**self.__params), attrname)
+
 
 def get_docker_client():
     """Get the user's docker client.
@@ -142,7 +155,7 @@ def get_docker_client():
             assert_hostname=False)
 
     # pylint: disable=star-args
-    client = docker.Client(version=DOCKER_API_VERSION,
+    client = ClientWrapper(version=DOCKER_API_VERSION,
                            timeout=TIMEOUT_SECS,
                            **params)
     try:


### PR DESCRIPTION
This works around the Docker "Hijack incompatible with close notifier" bug.  See https://github.com/docker/docker/issues/12845 for details.  The prescribed work-around is to reconnect.  This change takes the ham-fisted approach of reconnecting on every access, which actually works pretty well.

Change-Id: If202f797b29f2a0eba6aa14c947a5ca10ad555c0
