### PR TITLE
Use `gcloud app` instead of `gcloud preview app`

### DIFF
--- a/appstart/devappserver_init/Dockerfile
+++ b/appstart/devappserver_init/Dockerfile
@@ -18,6 +18,6 @@ RUN apt-get update
 RUN apt-get install -y python curl python-pip
 RUN curl https://dl.google.com/dl/cloudsdk/release/install_google_cloud_sdk.bash > install.sh
 RUN bash ./install.sh --disable-prompts --install-dir ./sdk
-RUN SDK_ROOT=$(echo /sdk/$(ls sdk/)); $(echo $SDK_ROOT/bin/gcloud components update --quiet preview app app-engine-python app-engine-php app-engine-java)
+RUN SDK_ROOT=$(echo /sdk/$(ls sdk/)); $(echo $SDK_ROOT/bin/gcloud components update --quiet app app-engine-python app-engine-php app-engine-java)
 ADD ./das.sh /
 ENTRYPOINT /das.sh


### PR DESCRIPTION
We should use `gcloud app` instead of `gcloud preview app` which will go away soon.
